### PR TITLE
Modify theme to have inactive tabs as purple

### DIFF
--- a/themes/N64AweSoMe-theme.json
+++ b/themes/N64AweSoMe-theme.json
@@ -22,7 +22,9 @@
         "input.background": "#222244",
         "input.border": "#666699",
         "button.background": "#777799",
-        "notifications.background": "#222244"
+        "notifications.background": "#222244",
+        "tab.inactiveBackground": "#222244",
+        "editorGroupHeader.tabsBackground": "#222244"
     },
     "tokenColors": [
         {


### PR DESCRIPTION
Make tab bar have consistent purple color. See tab bar in screen shot for new consistent color scheme.

![Theme screen shot](https://user-images.githubusercontent.com/1855648/89206985-00911c80-d588-11ea-8317-d79dfa2dc3e5.png)
